### PR TITLE
Fix issue 6: allow staff to edit customization options

### DIFF
--- a/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Customer/MenuActivity.java
+++ b/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Customer/MenuActivity.java
@@ -50,7 +50,7 @@ public class MenuActivity extends AppCompatActivity {
         btnPayment = findViewById(R.id.btnPayment);
         btnViewCart = findViewById(R.id.btnViewCart);
 
-        menuList = new ArrayList<>(AppData.menuItems);
+        menuList = AppData.menuItems;
         adapter = new MenuAdapter(menuList);
 
         recyclerMenu.setLayoutManager(new LinearLayoutManager(this));
@@ -183,5 +183,12 @@ public class MenuActivity extends AppCompatActivity {
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean("isServerCalled", isServerCalled);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        filterMenu("Food");
+        updateCategoryButtonStyles(btnFood);
     }
 }

--- a/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Customer/ModificationItemActivity.java
+++ b/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Customer/ModificationItemActivity.java
@@ -2,8 +2,10 @@ package com.example.cosc341_group_8_step_4.ui.Customer;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
+import android.widget.GridLayout;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -15,7 +17,7 @@ import java.util.ArrayList;
 public class ModificationItemActivity extends AppCompatActivity {
 
     private TextView tvDishName;
-    private CheckBox cbOption1, cbOption2, cbOption3, cbOption4, cbOption5, cbOption6;
+    private GridLayout layoutOptions;
     private Button btnBack, btnAdditionalRequirement;
 
     private String itemName;
@@ -29,12 +31,7 @@ public class ModificationItemActivity extends AppCompatActivity {
 
         tvDishName = findViewById(R.id.tvDishName);
 
-        cbOption1 = findViewById(R.id.cbOption1);
-        cbOption2 = findViewById(R.id.cbOption2);
-        cbOption3 = findViewById(R.id.cbOption3);
-        cbOption4 = findViewById(R.id.cbOption4);
-        cbOption5 = findViewById(R.id.cbOption5);
-        cbOption6 = findViewById(R.id.cbOption6);
+        layoutOptions = findViewById(R.id.layoutOptions);
 
         btnBack = findViewById(R.id.btnBack);
         btnAdditionalRequirement = findViewById(R.id.btnAdditionalRequirement);
@@ -55,23 +52,14 @@ public class ModificationItemActivity extends AppCompatActivity {
         btnAdditionalRequirement.setOnClickListener(v -> {
             ArrayList<String> selectedOptions = new ArrayList<>();
 
-            if (cbOption1.getVisibility() == CheckBox.VISIBLE && cbOption1.isChecked()) {
-                selectedOptions.add(cbOption1.getText().toString());
-            }
-            if (cbOption2.getVisibility() == CheckBox.VISIBLE && cbOption2.isChecked()) {
-                selectedOptions.add(cbOption2.getText().toString());
-            }
-            if (cbOption3.getVisibility() == CheckBox.VISIBLE && cbOption3.isChecked()) {
-                selectedOptions.add(cbOption3.getText().toString());
-            }
-            if (cbOption4.getVisibility() == CheckBox.VISIBLE && cbOption4.isChecked()) {
-                selectedOptions.add(cbOption4.getText().toString());
-            }
-            if (cbOption5.getVisibility() == CheckBox.VISIBLE && cbOption5.isChecked()) {
-                selectedOptions.add(cbOption5.getText().toString());
-            }
-            if (cbOption6.getVisibility() == CheckBox.VISIBLE && cbOption6.isChecked()) {
-                selectedOptions.add(cbOption6.getText().toString());
+            for (int i = 0; i < layoutOptions.getChildCount(); i++) {
+                View child = layoutOptions.getChildAt(i);
+                if (child instanceof CheckBox) {
+                    CheckBox checkBox = (CheckBox) child;
+                    if (checkBox.isChecked()) {
+                        selectedOptions.add(checkBox.getText().toString());
+                    }
+                }
             }
 
             Intent intent = new Intent(ModificationItemActivity.this, AdditionalRequirementActivity.class);
@@ -83,15 +71,22 @@ public class ModificationItemActivity extends AppCompatActivity {
     }
 
     private void setCheckboxOptions(String[] options) {
-        CheckBox[] checkBoxes = {cbOption1, cbOption2, cbOption3, cbOption4, cbOption5, cbOption6};
+        layoutOptions.removeAllViews();
 
-        for (int i = 0; i < checkBoxes.length; i++) {
-            if (options != null && i < options.length) {
-                checkBoxes[i].setText(options[i]);
-                checkBoxes[i].setVisibility(CheckBox.VISIBLE);
-            } else {
-                checkBoxes[i].setVisibility(CheckBox.GONE);
-            }
+        if (options == null) return;
+
+        for (String option : options) {
+            CheckBox checkBox = new CheckBox(this);
+            checkBox.setText(option);
+            checkBox.setTextSize(18);
+
+            GridLayout.LayoutParams params = new GridLayout.LayoutParams();
+            params.width = 0;
+            params.columnSpec = GridLayout.spec(GridLayout.UNDEFINED, 1f);
+            params.setMargins(16, 16, 16, 16);
+            checkBox.setLayoutParams(params);
+
+            layoutOptions.addView(checkBox);
         }
     }
 }

--- a/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Staff/AddEditMenuItemActivity.java
+++ b/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Staff/AddEditMenuItemActivity.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 
 public class AddEditMenuItemActivity extends AppCompatActivity {
 
-    private EditText etName, etDescription, etPrice;
+    private EditText etName, etDescription, etPrice, etOptions;
     private Spinner spinnerCategory;
     private Button btnSave, btnCancel, btnUploadFoodImage;
     private ImageView imgFoodPreview;
@@ -57,6 +57,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
         btnCancel = findViewById(R.id.btnCancelItem);
         btnUploadFoodImage = findViewById(R.id.btnUploadFoodImage);
         imgFoodPreview = findViewById(R.id.imgFoodPreview);
+        etOptions = findViewById(R.id.etItemOptions);
 
         String[] categories = {"Food", "Drinks", "Desserts"};
         spinnerCategory.setAdapter(new ArrayAdapter<>(
@@ -70,6 +71,10 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
 
         if ("edit".equals(mode) && itemIndex >= 0) {
             MenuItem item = AppData.menuItems.get(itemIndex);
+
+            if (item.options != null && item.options.length > 0) {
+                etOptions.setText(String.join(", ", item.options));
+            }
 
             etName.setText(item.name);
             etDescription.setText(item.description);
@@ -109,6 +114,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
         String description = etDescription.getText().toString().trim();
         String priceText = etPrice.getText().toString().trim();
         String category = spinnerCategory.getSelectedItem().toString();
+        String optionsText = etOptions.getText().toString().trim();
 
         if (name.isEmpty() || description.isEmpty() || priceText.isEmpty()) {
             Toast.makeText(this, "Please fill all fields", Toast.LENGTH_SHORT).show();
@@ -136,6 +142,14 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
             finalImageResId = 0;
         }
 
+        String[] optionsArray;
+
+        if (optionsText.isEmpty()) {
+            optionsArray = new String[0];
+        } else {
+            optionsArray = optionsText.split("\\s*,\\s*");
+        }
+
         if ("edit".equals(mode) && itemIndex >= 0) {
             MenuItem item = AppData.menuItems.get(itemIndex);
 
@@ -145,11 +159,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
             item.category = category;
             item.imagePath = finalImagePath;
             item.imageResId = finalImageResId;
-
-            if (item.options == null) {
-                item.options = new String[]{"Option 1","Option 2","Option 3","Option 4","Option 5","Option 6"};
-            }
-
+            item.options = optionsArray;
         } else {
             MenuItem newItem = new MenuItem(
                     name,
@@ -158,7 +168,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
                     category,
                     finalImageResId,
                     finalImagePath,
-                    new String[]{"Option 1","Option 2","Option 3","Option 4","Option 5","Option 6"}
+                    optionsArray
             );
 
             AppData.addMenuItem(newItem);

--- a/app/src/main/res/layout/activity_add_edit_menu_item.xml
+++ b/app/src/main/res/layout/activity_add_edit_menu_item.xml
@@ -74,6 +74,23 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="12dp" />
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Customization Options"
+            android:textStyle="bold"
+            android:layout_marginTop="16dp" />
+
+        <EditText
+            android:id="@+id/etItemOptions"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Enter options separated by commas"
+            android:minLines="3"
+            android:gravity="top|start"
+            android:inputType="textMultiLine"
+            android:layout_marginTop="8dp" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_modification_item.xml
+++ b/app/src/main/res/layout/activity_modification_item.xml
@@ -32,109 +32,45 @@
             android:textColor="#222222"
             android:layout_marginBottom="24dp" />
 
-        <!-- Options Row 1 -->
-        <LinearLayout
+        <GridLayout
+            android:id="@+id/layoutOptions"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginBottom="20dp"
-            android:weightSum="2">
-
-            <CheckBox
-                android:id="@+id/cbOption1"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Option 1"
-                android:textSize="18sp" />
-
-            <CheckBox
-                android:id="@+id/cbOption2"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Option 2"
-                android:textSize="18sp" />
-        </LinearLayout>
-
-        <!-- Options Row 2 -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginBottom="20dp"
-            android:weightSum="2">
-
-            <CheckBox
-                android:id="@+id/cbOption3"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Option 3"
-                android:textSize="18sp" />
-
-            <CheckBox
-                android:id="@+id/cbOption4"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Option 4"
-                android:textSize="18sp" />
-        </LinearLayout>
-
-        <!-- Options Row 3 -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginBottom="40dp"
-            android:weightSum="2">
-
-            <CheckBox
-                android:id="@+id/cbOption5"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Option 5"
-                android:textSize="18sp" />
-
-            <CheckBox
-                android:id="@+id/cbOption6"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Option 6"
-                android:textSize="18sp" />
-        </LinearLayout>
+            android:columnCount="2"
+            android:rowCount="3"
+            android:useDefaultMargins="true"
+            android:alignmentMode="alignMargins"
+            android:layout_marginTop="16dp" />
 
         <!-- Buttons -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:weightSum="2">
+            android:weightSum="2"
+            android:baselineAligned="false">
 
             <Button
                 android:id="@+id/btnBack"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
                 android:layout_weight="1"
+                android:backgroundTint="#D32F2F"
                 android:text="Back"
                 android:textAllCaps="false"
-                android:textColor="#FFFFFF"
-                android:backgroundTint="#D32F2F"
-                android:layout_marginEnd="8dp" />
+                android:textColor="#FFFFFF" />
 
             <Button
                 android:id="@+id/btnAdditionalRequirement"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
                 android:layout_weight="1"
+                android:backgroundTint="#2E7D32"
                 android:text="Additional Requirement"
                 android:textAllCaps="false"
-                android:textColor="#FFFFFF"
-                android:backgroundTint="#2E7D32"
-                android:layout_marginStart="8dp" />
+                android:textColor="#FFFFFF" />
         </LinearLayout>
 
     </LinearLayout>


### PR DESCRIPTION
This PR fixes issue #6 by allowing staff to edit customization options on the Add/Edit Item page.

Changes made:
- added a customization options input field on the staff Add/Edit Item page
- saved customization options into MenuItem.options
- refreshed customer menu data so updated options are reflected