### PR TITLE
Fix issue 7: add available/unavailable item status

### DIFF
--- a/app/src/main/java/com/example/cosc341_group_8_step_4/model/MenuItem.java
+++ b/app/src/main/java/com/example/cosc341_group_8_step_4/model/MenuItem.java
@@ -8,6 +8,7 @@ public class MenuItem {
     public int imageResId;
     public String imagePath;
     public String[] options;
+    public boolean isAvailable;
 
     public MenuItem(String name, String description, double price, String category, int imageResId, String[] options) {
         this.name = name;
@@ -17,6 +18,7 @@ public class MenuItem {
         this.imageResId = imageResId;
         this.imagePath = null;
         this.options = options;
+        this.isAvailable = true;
     }
 
     public MenuItem(String name, String description, double price, String category, int imageResId, String imagePath, String[] options) {
@@ -27,5 +29,6 @@ public class MenuItem {
         this.imageResId = imageResId;
         this.imagePath = imagePath;
         this.options = options;
+        this.isAvailable = true;
     }
 }

--- a/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Customer/MenuAdapter.java
+++ b/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Customer/MenuAdapter.java
@@ -43,6 +43,16 @@ public class MenuAdapter extends RecyclerView.Adapter<MenuAdapter.ViewHolder> {
         holder.description.setText(item.description);
         holder.price.setText(String.format(Locale.US, "$%.2f", item.price));
 
+        if (item.isAvailable) {
+            holder.addBtn.setEnabled(true);
+            holder.addBtn.setText("Add");
+            holder.itemView.setAlpha(1.0f);
+        } else {
+            holder.addBtn.setEnabled(false);
+            holder.addBtn.setText("Unavailable");
+            holder.itemView.setAlpha(0.5f);
+        }
+
         if (item.imagePath != null && !item.imagePath.isEmpty()) {
             File file = new File(item.imagePath);
             if (file.exists()) {
@@ -59,6 +69,9 @@ public class MenuAdapter extends RecyclerView.Adapter<MenuAdapter.ViewHolder> {
         }
 
         holder.addBtn.setOnClickListener(v -> {
+            if (!item.isAvailable) {
+                return;
+            }
             Intent intent = new Intent(v.getContext(), ModificationItemActivity.class);
             intent.putExtra("itemName", item.name);
             intent.putExtra("itemPrice", item.price);

--- a/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Staff/AddEditMenuItemActivity.java
+++ b/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Staff/AddEditMenuItemActivity.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.Spinner;
@@ -28,6 +29,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
     private Spinner spinnerCategory;
     private Button btnSave, btnCancel, btnUploadFoodImage;
     private ImageView imgFoodPreview;
+    private CheckBox cbItemAvailable;
 
     private String mode;
     private int itemIndex = -1;
@@ -58,6 +60,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
         btnUploadFoodImage = findViewById(R.id.btnUploadFoodImage);
         imgFoodPreview = findViewById(R.id.imgFoodPreview);
         etOptions = findViewById(R.id.etItemOptions);
+        cbItemAvailable = findViewById(R.id.cbItemAvailable);
 
         String[] categories = {"Food", "Drinks", "Desserts"};
         spinnerCategory.setAdapter(new ArrayAdapter<>(
@@ -79,6 +82,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
             etName.setText(item.name);
             etDescription.setText(item.description);
             etPrice.setText(String.valueOf(item.price));
+            cbItemAvailable.setChecked(item.isAvailable);
 
             currentImagePath = item.imagePath;
             currentImageResId = item.imageResId;
@@ -115,6 +119,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
         String priceText = etPrice.getText().toString().trim();
         String category = spinnerCategory.getSelectedItem().toString();
         String optionsText = etOptions.getText().toString().trim();
+        boolean isAvailable = cbItemAvailable.isChecked();
 
         if (name.isEmpty() || description.isEmpty() || priceText.isEmpty()) {
             Toast.makeText(this, "Please fill all fields", Toast.LENGTH_SHORT).show();
@@ -160,6 +165,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
             item.imagePath = finalImagePath;
             item.imageResId = finalImageResId;
             item.options = optionsArray;
+            item.isAvailable = isAvailable;
         } else {
             MenuItem newItem = new MenuItem(
                     name,
@@ -171,6 +177,7 @@ public class AddEditMenuItemActivity extends AppCompatActivity {
                     optionsArray
             );
 
+            newItem.isAvailable = isAvailable;
             AppData.addMenuItem(newItem);
         }
 

--- a/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Staff/ManageMenuAdapter.java
+++ b/app/src/main/java/com/example/cosc341_group_8_step_4/ui/Staff/ManageMenuAdapter.java
@@ -3,6 +3,7 @@ package com.example.cosc341_group_8_step_4.ui.Staff;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -47,6 +48,15 @@ public class ManageMenuAdapter extends RecyclerView.Adapter<ManageMenuAdapter.Vi
         holder.tvName.setText(item.name);
         holder.tvCategory.setText("Category: " + item.category);
         holder.tvPrice.setText(String.format(Locale.US, "$%.2f", item.price));
+        if (item.isAvailable) {
+            holder.tvStatus.setText("Available");
+            holder.tvStatus.setTextColor(Color.parseColor("#2E7D32"));
+            holder.itemView.setAlpha(1.0f);
+        } else {
+            holder.tvStatus.setText("Unavailable");
+            holder.tvStatus.setTextColor(Color.parseColor("#D32F2F"));
+            holder.itemView.setAlpha(0.5f);
+        }
 
         if (item.imagePath != null && !item.imagePath.isEmpty()) {
             File file = new File(item.imagePath);
@@ -94,7 +104,7 @@ public class ManageMenuAdapter extends RecyclerView.Adapter<ManageMenuAdapter.Vi
 
     public static class ViewHolder extends RecyclerView.ViewHolder {
         ImageView imgItem;
-        TextView tvName, tvCategory, tvPrice;
+        TextView tvName, tvCategory, tvPrice, tvStatus;
         Button btnEdit, btnDelete;
 
         public ViewHolder(@NonNull View itemView) {
@@ -104,6 +114,7 @@ public class ManageMenuAdapter extends RecyclerView.Adapter<ManageMenuAdapter.Vi
             tvName = itemView.findViewById(R.id.tvManageItemName);
             tvCategory = itemView.findViewById(R.id.tvManageItemCategory);
             tvPrice = itemView.findViewById(R.id.tvManageItemPrice);
+            tvStatus = itemView.findViewById(R.id.tvManageItemStatus);
             btnEdit = itemView.findViewById(R.id.btnEditItem);
             btnDelete = itemView.findViewById(R.id.btnDeleteItem);
         }

--- a/app/src/main/res/layout/activity_add_edit_menu_item.xml
+++ b/app/src/main/res/layout/activity_add_edit_menu_item.xml
@@ -91,11 +91,21 @@
             android:inputType="textMultiLine"
             android:layout_marginTop="8dp" />
 
+        <CheckBox
+            android:id="@+id/cbItemAvailable"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Available"
+            android:textSize="18sp"
+            android:textColor="#000000" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:weightSum="2">
+            android:weightSum="2"
+            android:layout_marginTop="20dp">
 
             <Button
                 android:id="@+id/btnSaveItem"

--- a/app/src/main/res/layout/item_manage_menu.xml
+++ b/app/src/main/res/layout/item_manage_menu.xml
@@ -49,7 +49,16 @@
             android:layout_marginTop="4dp"
             android:layout_marginBottom="8dp" />
 
-
+        <TextView
+            android:id="@+id/tvManageItemStatus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Available"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:textColor="#2E7D32"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="4dp" />
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
This PR fixes issue #7 by adding an available/unavailable status option to the staff Add/Edit Item interface.

Changes made:
	•	added an “Available” checkbox on the staff Add/Edit Item page
	•	saved item availability status in the MenuItem model
	•	updated the staff menu to display Available/Unavailable status
	•	greyed out unavailable items in the staff menu while keeping Edit/Delete usable
	•	updated the customer menu so unavailable items appear greyed out
	•	changed the customer button text to “Unavailable” and prevented unavailable items from being selected